### PR TITLE
Fix bash string interpolation in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Now, access Kong's Admin API via the protected, public-facing proxy:
 
 ```bash
 # Set the request header:
-curl -H 'apikey: $ADMIN_KEY' https://$APP_NAME.herokuapp.com/kong-admin/status
+curl -H "apikey: $ADMIN_KEY" https://$APP_NAME.herokuapp.com/kong-admin/status
 # or use query params:
 curl https://$APP_NAME.herokuapp.com/kong-admin/status?apikey=$ADMIN_KEY
 ```


### PR DESCRIPTION
I was walking through the steps to secure the adming api and was having trouble checking the status. I realized that the `$ADMIN_KEY` was not being interpolated in the header because it contained in a single-quoted string.