### PR TITLE
🚨 Switch prefix from `/app/.heroku` to `/app/kong-runtime`

### DIFF
--- a/ADMIN.md
+++ b/ADMIN.md
@@ -23,7 +23,7 @@ heroku run bash --app $APP_NAME
 # (Note: some commands require the config file and others the prefix)
 # (Note: the `$KONG_CONF` variable is already defined)
 ~ $ kong migrations list -c $KONG_CONF
-~ $ kong health -p /app/.heroku
+~ $ kong health -p /app/kong-runtime
 ```
 
 ### Proxy & protect the Admin API

--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ heroku config:unset KONG_HEROKU_ADMIN_KEY
 
 ### Upgrade guide
 
+🚨 **Potentially breaking changes.** Please attempt upgrades on a staging system before upgrading production.
+
+#### The buildpack
+
+[Buildpack v6.0.0](https://github.com/heroku/heroku-buildpack-kong/releases) supports rapid deployments using a 
+pre-compiled Kong binary. Your pre-existing app may require changes continue functioning.
+
+▶️ See [UPGRADING the buildpack](https://github.com/heroku/heroku-buildpack-kong/blob/master/UPGRADING.md).
+
+#### Kong
+
 First, see [Kong's official upgrade path](https://github.com/Kong/kong/blob/master/UPGRADE.md).
 
 Then, take into account these facts about how this Kong on Heroku app works:

--- a/config/kong.conf.etlua
+++ b/config/kong.conf.etlua
@@ -23,7 +23,7 @@
 # GENERAL
 #------------------------------------------------------------------------------
 
-prefix = /app/.heroku/           # Working directory. Equivalent to Nginx's
+prefix = /app/kong-runtime/      # Working directory. Equivalent to Nginx's
                                  # prefix path, containing temporary files
                                  # and logs.
                                  # Each Kong process must have a separate


### PR DESCRIPTION
Change to match hopefully 🙏 upcoming [buildpack change](https://github.com/heroku/heroku-buildpack-kong/compare/precompiled-runtime).